### PR TITLE
ruby_ship.sh: Specify correct shebang for non-default bash distribution

### DIFF
--- a/bin/ruby_ship.sh
+++ b/bin/ruby_ship.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 OS="unknown"
 if [[ "$OSTYPE" == "linux"* ]]; then
 	OS="linux"
@@ -7,7 +8,7 @@ elif [[ "$OSTYPE" == "cygwin" ]]; then
 	OS="win"
 elif [[ "$OSTYPE" == "win32" ]]; then
 	OS="win"
-elif [[ "$OSTYPE" == "freebsd"* ]]; then
+elif [[ "$OSTYPE" == "FreeBSD"* ]]; then
 	OS="freebsd"
 else
 	echo "OS not compatible"

--- a/bin/ruby_ship_gem.sh
+++ b/bin/ruby_ship_gem.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 OS="unknown"
 if [[ "$OSTYPE" == "linux"* ]]; then
 	OS="linux"
@@ -7,7 +8,7 @@ elif [[ "$OSTYPE" == "cygwin" ]]; then
 	OS="win"
 elif [[ "$OSTYPE" == "win32" ]]; then
 	OS="win"
-elif [[ "$OSTYPE" == "freebsd"* ]]; then
+elif [[ "$OSTYPE" == "FreeBSD"* ]]; then
 	OS="freebsd"
 else
 	echo "OS not compatible"


### PR DESCRIPTION
Also fix OSTYPE values for FreeBSD