### PR TITLE
Fix detection of Ruby version for RUBY_VERSION_DIR

### DIFF
--- a/tools/ruby_ship_build.sh
+++ b/tools/ruby_ship_build.sh
@@ -53,8 +53,9 @@ make install
 
 
 #SETTING UP REFERENCE DIRECTORIES
-RUBY_INSTALL_DIR="$(ls $DIR/../bin/shipyard/${OS}_ruby/include)"
-RUBY_VERSION_DIR="$(echo $RUBY_INSTALL_DIR | cut -d'-' -f 2)"
+RUBY_MINOR_VERSION="$(echo $RUBY_VERSION | sed 's,\.[0-9]\+$,,')"
+RUBY_INSTALL_DIR="$(ls -d $DIR/../bin/shipyard/${OS}_ruby/include/ruby-${RUBY_MINOR_VERSION}*)"
+RUBY_VERSION_DIR="$(basename $RUBY_INSTALL_DIR | cut -d'-' -f 2)"
 RUBY_BINARY_INSTALL_DIR="$(ls $DIR/../bin/shipyard/${OS}_ruby/lib/ruby/$RUBY_VERSION_DIR | grep ${OS})"
 
 #SETTING UP COMMON WRAPPER COMPONENTS


### PR DESCRIPTION
This fixes a serious bug in the detection of the (newly installed) Ruby version that is used to build the `RUBY_VERSION_DIR` variable. The `bin/shipyard/linux_ruby/include` directory appears to contain one subdirectory per Ruby minor version (with an extra `.0` appended for good measure). Today, ruby_ship includes a 2.1.0 directory, so if I build Ruby 2.2.5 or 2.3.1, there will be a new, parallel directory in `include` (2.2.0 or 2.3.0 respectively).

The original detection code did not take into account the possibility of `ls` returning multiple directories, and hence resulting in some very strange values for `RUBY_VERSION_DIR`, which, when substituted into other values later in the script, broke the `linux_ruby.sh` wrapper script (and perhaps others).

This change attempts to calculate and use the Ruby minor version number (e.g., `2.3`) to build a glob for the `ls` command so that it returns only one directory name.

Also, there may have been a second bug if `DIR` contained a path that included a hyphen character. By using `basename` on the path returned by `ls`, that bug should be dealt with also.

Related to #15 